### PR TITLE
WIP: Update instances for Accelerate 1.4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ addons:
 matrix:
   fast_finish: true
   include:
+    - env: GHC=8.8.3
+      compiler: "GHC 8.8"
+
     - env: GHC=8.6.5
       compiler: "GHC 8.6"
 
@@ -38,9 +41,6 @@ matrix:
 
     - env: GHC=8.2.2
       compiler: "GHC 8.2"
-
-    - env: GHC=8.0.2
-      compiler: "GHC 8.0"
 
 before_install:
   - export PATH=/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:$PATH

--- a/accelerate-io-JuicyPixels/accelerate-io-JuicyPixels.cabal
+++ b/accelerate-io-JuicyPixels/accelerate-io-JuicyPixels.cabal
@@ -24,8 +24,8 @@ extra-source-files:
 
 library
   build-depends:
-          base                      >= 4.8 && < 4.13
-        , accelerate                >= 1.3
+          base                      >= 4.10 && < 4.14
+        , accelerate                >= 1.4
         , accelerate-io-vector      >= 0.1
         , vector
         , JuicyPixels               >= 3.2

--- a/accelerate-io-array/accelerate-io-array.cabal
+++ b/accelerate-io-array/accelerate-io-array.cabal
@@ -24,8 +24,8 @@ extra-source-files:
 
 library
   build-depends:
-          base            >= 4.8 && < 4.13
-        , accelerate      >= 1.3
+          base            >= 4.10 && < 4.14
+        , accelerate      >= 1.4
         , array           >= 0.3
         , primitive       >= 0.6
 
@@ -56,7 +56,7 @@ test-suite test-io
   ghc-options:          -main-is Test
 
   build-depends:
-        base                    >= 4.8  && < 4.13
+        base                    >= 4.10 && < 4.14
       , accelerate
       , accelerate-io-array
       , array

--- a/accelerate-io-array/src/Data/Array/Accelerate/IO/Data/Primitive/ByteArray.hs
+++ b/accelerate-io-array/src/Data/Array/Accelerate/IO/Data/Primitive/ByteArray.hs
@@ -31,7 +31,7 @@ byteArrayOfForeignPtr (I# bytes#) (ForeignPtr addr# c) = IO $ \s ->
     PlainPtr mba# -> case unsafeFreezeByteArray# mba# s of
                        (# s', ba#  #) -> (# s', ByteArray ba# #)
 
-    _             -> case newAlignedPinnedByteArray# bytes# 16# s      of { (# s1, mba# #) ->
+    _             -> case newAlignedPinnedByteArray# bytes# 64# s      of { (# s1, mba# #) ->
                      case copyAddrToByteArray# addr# mba# 0# bytes# s1 of { s2 ->
                      case unsafeFreezeByteArray# mba# s2               of { (# s3, ba# #) ->
                        (# s3, ByteArray ba# #) }}}
@@ -44,7 +44,7 @@ byteArrayOfForeignPtr (I# bytes#) (ForeignPtr addr# c) = IO $ \s ->
 foreignPtrOfByteArray :: Int -> Int -> ByteArray -> IO (ForeignPtr a)
 foreignPtrOfByteArray (I# soff#) (I# bytes#) (ByteArray ba#) = IO $ \s ->
   case isByteArrayPinned# ba# of
-    0# -> case newAlignedPinnedByteArray# bytes# 16# s    of { (# s1, mba# #) ->
+    0# -> case newAlignedPinnedByteArray# bytes# 64# s    of { (# s1, mba# #) ->
           case copyByteArray# ba# 0# mba# soff# bytes# s1 of { s2 ->
             (# s2, ForeignPtr (byteArrayContents# (unsafeCoerce# mba#)) (PlainPtr mba#) #) }}
 

--- a/accelerate-io-bmp/accelerate-io-bmp.cabal
+++ b/accelerate-io-bmp/accelerate-io-bmp.cabal
@@ -24,8 +24,8 @@ extra-source-files:
 
 library
   build-depends:
-          base                      >= 4.8 && < 4.13
-        , accelerate                >= 1.3
+          base                      >= 4.10 && < 4.14
+        , accelerate                >= 1.4
         , accelerate-io-bytestring  >= 0.1
         , bmp                       >= 1.2
 

--- a/accelerate-io-bytestring/accelerate-io-bytestring.cabal
+++ b/accelerate-io-bytestring/accelerate-io-bytestring.cabal
@@ -24,8 +24,8 @@ extra-source-files:
 
 library
   build-depends:
-          base            >= 4.8 && < 4.13
-        , accelerate      >= 1.3
+          base            >= 4.10 && < 4.14
+        , accelerate      >= 1.4
         , bytestring      >= 0.9
 
   exposed-modules:

--- a/accelerate-io-cereal/accelerate-io-cereal.cabal
+++ b/accelerate-io-cereal/accelerate-io-cereal.cabal
@@ -24,8 +24,8 @@ extra-source-files:
 
 library
   build-depends:
-          base                      >= 4.8 && < 4.13
-        , accelerate                >= 1.3
+          base                      >= 4.10 && < 4.14
+        , accelerate                >= 1.4
         , accelerate-io-bytestring  >= 0.1
         , bytestring                >= 0.9
         , cereal                    >= 0.5

--- a/accelerate-io-repa/accelerate-io-repa.cabal
+++ b/accelerate-io-repa/accelerate-io-repa.cabal
@@ -24,8 +24,8 @@ extra-source-files:
 
 library
   build-depends:
-          base            >= 4.8 && < 4.13
-        , accelerate      >= 1.3
+          base            >= 4.10 && < 4.14
+        , accelerate      >= 1.4
         , repa            >= 3.2
 
   exposed-modules:

--- a/accelerate-io-vector/accelerate-io-vector.cabal
+++ b/accelerate-io-vector/accelerate-io-vector.cabal
@@ -37,6 +37,7 @@ library
         Data.Array.Accelerate.IO.Data.Vector.Unboxed
 
   other-modules:
+        Data.Array.Accelerate.IO.Data.Patterns
         Data.Array.Accelerate.IO.Data.Primitive.ByteArray
         Data.Array.Accelerate.IO.Data.Vector.Primitive.Internal
 

--- a/accelerate-io-vector/accelerate-io-vector.cabal
+++ b/accelerate-io-vector/accelerate-io-vector.cabal
@@ -24,8 +24,8 @@ extra-source-files:
 
 library
   build-depends:
-          base            >= 4.8 && < 4.13
-        , accelerate      >= 1.3
+          base            >= 4.10 && < 4.14
+        , accelerate      >= 1.4
         , primitive       >= 0.6
         , vector          >= 0.9
 
@@ -59,7 +59,7 @@ test-suite test-io
   ghc-options:          -main-is Test
 
   build-depends:
-        base                    >= 4.8  && < 4.13
+        base                    >= 4.10 && < 4.14
       , accelerate
       , accelerate-io-vector
       , hedgehog                >= 0.5

--- a/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Patterns.hs
+++ b/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Patterns.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE GADTs           #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE MagicHash       #-}
+
+-- | Pattern synonyms for working with 'TupleType'
+--
+-- TODO: This module should be either moved to some common place where all
+--       @accelerate-io-*@ packages can access them, or the patterns should just
+--       be inlined
+
+module Data.Array.Accelerate.IO.Data.Patterns where
+
+import Data.Array.Accelerate.Type
+import GHC.Base
+
+-- TODO: Missing one of these patterns doesn't trigger a warning about
+--       non-exhaustive patterns, how could this be resolved?
+
+{-# COMPLETE TupInt, TupInt, TupInt8, TupInt8, TupInt16,
+             TupInt16, TupInt32, TupInt32, TupInt64, TupInt64, TupWord, TupWord,
+             TupWord8, TupWord8, TupWord16, TupWord16, TupWord32, TupWord32,
+             TupWord64, TupWord64, TupHalf, TupHalf, TupFloat, TupFloat,
+             TupDouble, TupDouble, TupBool, TupBool, TupChar, TupChar #-}
+{-# COMPLETE TupVecInt, TupVecInt, TupVecInt8, TupVecInt8, TupVecInt16,
+             TupVecInt16, TupVecInt32, TupVecInt32, TupVecInt64, TupVecInt64,
+             TupVecWord, TupVecWord, TupVecWord8, TupVecWord8, TupVecWord16,
+             TupVecWord16, TupVecWord32, TupVecWord32, TupVecWord64,
+             TupVecWord64, TupVecHalf, TupVecHalf, TupVecFloat, TupVecFloat,
+             TupVecDouble, TupVecDouble, TupVecBool, TupVecBool, TupVecChar,
+             TupVecChar #-}
+pattern TupInt    :: () => a ~ Int => TupleType a
+pattern TupInt    = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt)))
+pattern TupInt8   :: () => a ~ Int8 => TupleType a
+pattern TupInt8   = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt8)))
+pattern TupInt16  :: () => a ~ Int16 => TupleType a
+pattern TupInt16  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt16)))
+pattern TupInt32  :: () => a ~ Int32 => TupleType a
+pattern TupInt32  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt32)))
+pattern TupInt64  :: () => a ~ Int64 => TupleType a
+pattern TupInt64  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt64)))
+pattern TupWord   :: () => a ~ Word => TupleType a
+pattern TupWord   = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord)))
+pattern TupWord8  :: () => a ~ Word8 => TupleType a
+pattern TupWord8  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord8)))
+pattern TupWord16 :: () => a ~ Word16 => TupleType a
+pattern TupWord16 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord16)))
+pattern TupWord32 :: () => a ~ Word32 => TupleType a
+pattern TupWord32 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord32)))
+pattern TupWord64 :: () => a ~ Word64 => TupleType a
+pattern TupWord64 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord64)))
+pattern TupHalf   :: () => a ~ Half => TupleType a
+pattern TupHalf   = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeHalf)))
+pattern TupFloat  :: () => a ~ Float => TupleType a
+pattern TupFloat  = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeFloat)))
+pattern TupDouble :: () => a ~ Double => TupleType a
+pattern TupDouble = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeDouble)))
+pattern TupBool   :: () => a ~ Bool => TupleType a
+pattern TupBool   = TupRsingle (SingleScalarType (NonNumSingleType TypeBool))
+pattern TupChar   :: () => a ~ Char => TupleType a
+pattern TupChar   = TupRsingle (SingleScalarType (NonNumSingleType TypeChar))
+-- TODO: I can't get the type checker to accept these VectorScalarTypes without
+--       having to manually match all possible options, how should this be done
+--       instead?
+pattern TupVecInt    :: () => (a ~ Int, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt    n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt))))
+pattern TupVecInt8   :: () => (a ~ Int8, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt8   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt8))))
+pattern TupVecInt16  :: () => (a ~ Int16, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt16  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt16))))
+pattern TupVecInt32  :: () => (a ~ Int32, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt32  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt32))))
+pattern TupVecInt64  :: () => (a ~ Int64, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt64  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt64))))
+pattern TupVecWord   :: () => (a ~ Word, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord))))
+pattern TupVecWord8  :: () => (a ~ Word8, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord8  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord8))))
+pattern TupVecWord16 :: () => (a ~ Word16, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord16 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord16))))
+pattern TupVecWord32 :: () => (a ~ Word32, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord32 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord32))))
+pattern TupVecWord64 :: () => (a ~ Word64, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord64 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord64))))
+pattern TupVecHalf   :: () => (a ~ Half, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecHalf   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeHalf))))
+pattern TupVecFloat  :: () => (a ~ Float, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecFloat  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeFloat))))
+pattern TupVecDouble :: () => (a ~ Double, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecDouble n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeDouble))))
+pattern TupVecBool   :: () => (a ~ Bool, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecBool   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NonNumSingleType TypeBool)))
+pattern TupVecChar   :: () => (a ~ Char, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecChar   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NonNumSingleType TypeChar)))

--- a/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Primitive/ByteArray.hs
+++ b/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Primitive/ByteArray.hs
@@ -31,7 +31,7 @@ byteArrayOfForeignPtr (I# bytes#) (ForeignPtr addr# c) = IO $ \s ->
     PlainPtr mba# -> case unsafeFreezeByteArray# mba# s of
                        (# s', ba#  #) -> (# s', ByteArray ba# #)
 
-    _             -> case newAlignedPinnedByteArray# bytes# 16# s      of { (# s1, mba# #) ->
+    _             -> case newAlignedPinnedByteArray# bytes# 64# s      of { (# s1, mba# #) ->
                      case copyAddrToByteArray# addr# mba# 0# bytes# s1 of { s2 ->
                      case unsafeFreezeByteArray# mba# s2               of { (# s3, ba# #) ->
                        (# s3, ByteArray ba# #) }}}
@@ -44,7 +44,7 @@ byteArrayOfForeignPtr (I# bytes#) (ForeignPtr addr# c) = IO $ \s ->
 foreignPtrOfByteArray :: Int -> Int -> ByteArray -> IO (ForeignPtr a)
 foreignPtrOfByteArray (I# soff#) (I# bytes#) (ByteArray ba#) = IO $ \s ->
   case isByteArrayPinned# ba# of
-    0# -> case newAlignedPinnedByteArray# bytes# 16# s    of { (# s1, mba# #) ->
+    0# -> case newAlignedPinnedByteArray# bytes# 64# s    of { (# s1, mba# #) ->
           case copyByteArray# ba# 0# mba# soff# bytes# s1 of { s2 ->
             (# s2, ForeignPtr (byteArrayContents# (unsafeCoerce# mba#)) (PlainPtr mba#) #) }}
 

--- a/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Vector/Generic/Mutable.hs
+++ b/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Vector/Generic/Mutable.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeApplications      #-}
@@ -34,6 +33,8 @@ import Data.Array.Accelerate.Array.Unique
 import Data.Array.Accelerate.Lifetime
 import Data.Array.Accelerate.Type
 
+import Data.Array.Accelerate.IO.Data.Patterns
+
 import qualified Data.Vector.Generic.Mutable                        as V
 
 import Control.Monad.Primitive
@@ -45,90 +46,6 @@ import Prelude                                                      hiding ( len
 
 import GHC.Base
 import GHC.ForeignPtr
-
--- | Pattern synonyms for pattern matching on 'TupleType' instances.
---
--- TODO: These should be in some common place where very accelerate-io-* package
---       can access them. Should these be part of Accelerate itself?
--- TODO: Missing one of these patterns doesn't trigger a warning about
---       non-exhaustive patterns, how could this be resolved?
---
-
-{-# COMPLETE TupRunit, TupRpair, TupInt, TupInt, TupInt8, TupInt8, TupInt16,
-             TupInt16, TupInt32, TupInt32, TupInt64, TupInt64, TupWord, TupWord,
-             TupWord8, TupWord8, TupWord16, TupWord16, TupWord32, TupWord32,
-             TupWord64, TupWord64, TupHalf, TupHalf, TupFloat, TupFloat,
-             TupDouble, TupDouble, TupBool, TupBool, TupChar, TupChar,
-             TupVecInt, TupVecInt, TupVecInt8, TupVecInt8, TupVecInt16,
-             TupVecInt16, TupVecInt32, TupVecInt32, TupVecInt64, TupVecInt64,
-             TupVecWord, TupVecWord, TupVecWord8, TupVecWord8, TupVecWord16,
-             TupVecWord16, TupVecWord32, TupVecWord32, TupVecWord64,
-             TupVecWord64, TupVecHalf, TupVecHalf, TupVecFloat, TupVecFloat,
-             TupVecDouble, TupVecDouble, TupVecBool, TupVecBool, TupVecChar,
-             TupVecChar #-}
-pattern TupInt    :: () => a ~ Int => TupleType a
-pattern TupInt    = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt)))
-pattern TupInt8   :: () => a ~ Int8 => TupleType a
-pattern TupInt8   = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt8)))
-pattern TupInt16  :: () => a ~ Int16 => TupleType a
-pattern TupInt16  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt16)))
-pattern TupInt32  :: () => a ~ Int32 => TupleType a
-pattern TupInt32  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt32)))
-pattern TupInt64  :: () => a ~ Int64 => TupleType a
-pattern TupInt64  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt64)))
-pattern TupWord   :: () => a ~ Word => TupleType a
-pattern TupWord   = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord)))
-pattern TupWord8  :: () => a ~ Word8 => TupleType a
-pattern TupWord8  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord8)))
-pattern TupWord16 :: () => a ~ Word16 => TupleType a
-pattern TupWord16 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord16)))
-pattern TupWord32 :: () => a ~ Word32 => TupleType a
-pattern TupWord32 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord32)))
-pattern TupWord64 :: () => a ~ Word64 => TupleType a
-pattern TupWord64 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord64)))
-pattern TupHalf   :: () => a ~ Half => TupleType a
-pattern TupHalf   = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeHalf)))
-pattern TupFloat  :: () => a ~ Float => TupleType a
-pattern TupFloat  = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeFloat)))
-pattern TupDouble :: () => a ~ Double => TupleType a
-pattern TupDouble = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeDouble)))
-pattern TupBool   :: () => a ~ Bool => TupleType a
-pattern TupBool   = TupRsingle (SingleScalarType (NonNumSingleType TypeBool))
-pattern TupChar   :: () => a ~ Char => TupleType a
-pattern TupChar   = TupRsingle (SingleScalarType (NonNumSingleType TypeChar))
--- TODO: I can't get the type checker to accept these VectorScalarTypes without
---       having to manually match all possible options, how should this be done
---       instead?
-pattern TupVecInt    :: () => (a ~ Int, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecInt    n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt))))
-pattern TupVecInt8   :: () => (a ~ Int8, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecInt8   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt8))))
-pattern TupVecInt16  :: () => (a ~ Int16, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecInt16  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt16))))
-pattern TupVecInt32  :: () => (a ~ Int32, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecInt32  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt32))))
-pattern TupVecInt64  :: () => (a ~ Int64, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecInt64  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt64))))
-pattern TupVecWord   :: () => (a ~ Word, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecWord   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord))))
-pattern TupVecWord8  :: () => (a ~ Word8, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecWord8  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord8))))
-pattern TupVecWord16 :: () => (a ~ Word16, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecWord16 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord16))))
-pattern TupVecWord32 :: () => (a ~ Word32, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecWord32 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord32))))
-pattern TupVecWord64 :: () => (a ~ Word64, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecWord64 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord64))))
-pattern TupVecHalf   :: () => (a ~ Half, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecHalf   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeHalf))))
-pattern TupVecFloat  :: () => (a ~ Float, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecFloat  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeFloat))))
-pattern TupVecDouble :: () => (a ~ Double, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecDouble n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeDouble))))
-pattern TupVecBool   :: () => (a ~ Bool, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecBool   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NonNumSingleType TypeBool)))
-pattern TupVecChar   :: () => (a ~ Char, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
-pattern TupVecChar   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NonNumSingleType TypeChar)))
 
 -- | Dense, regular, mutable, multi-dimensional arrays
 --
@@ -178,6 +95,7 @@ instance Elt e => V.MVector MVector e where
       go (TupVecInt32 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecInt64 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecWord n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord8 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecWord16 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecWord32 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecWord64 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
@@ -217,6 +135,7 @@ instance Elt e => V.MVector MVector e where
       go (TupVecInt32 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecInt64 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecWord n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord8 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecWord16 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecWord32 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecWord64 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
@@ -271,6 +190,7 @@ instance Elt e => V.MVector MVector e where
       go (TupVecInt32 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecInt64 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecWord n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord8 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecWord16 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecWord32 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
       go (TupVecWord64 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
@@ -312,6 +232,7 @@ instance Elt e => V.MVector MVector e where
       go (TupVecInt32 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecInt64 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecWord n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord8 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecWord16 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecWord32 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
       go (TupVecWord64 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)

--- a/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Vector/Generic/Mutable.hs
+++ b/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Vector/Generic/Mutable.hs
@@ -5,8 +5,10 @@
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
 -- |
 -- Module      : Data.Array.Accelerate.IO.Data.Vector.Generic.Mutable
@@ -42,9 +44,91 @@ import Foreign.Storable
 import Prelude                                                      hiding ( length )
 
 import GHC.Base
-import GHC.TypeLits
 import GHC.ForeignPtr
 
+-- | Pattern synonyms for pattern matching on 'TupleType' instances.
+--
+-- TODO: These should be in some common place where very accelerate-io-* package
+--       can access them. Should these be part of Accelerate itself?
+-- TODO: Missing one of these patterns doesn't trigger a warning about
+--       non-exhaustive patterns, how could this be resolved?
+--
+
+{-# COMPLETE TupRunit, TupRpair, TupInt, TupInt, TupInt8, TupInt8, TupInt16,
+             TupInt16, TupInt32, TupInt32, TupInt64, TupInt64, TupWord, TupWord,
+             TupWord8, TupWord8, TupWord16, TupWord16, TupWord32, TupWord32,
+             TupWord64, TupWord64, TupHalf, TupHalf, TupFloat, TupFloat,
+             TupDouble, TupDouble, TupBool, TupBool, TupChar, TupChar,
+             TupVecInt, TupVecInt, TupVecInt8, TupVecInt8, TupVecInt16,
+             TupVecInt16, TupVecInt32, TupVecInt32, TupVecInt64, TupVecInt64,
+             TupVecWord, TupVecWord, TupVecWord8, TupVecWord8, TupVecWord16,
+             TupVecWord16, TupVecWord32, TupVecWord32, TupVecWord64,
+             TupVecWord64, TupVecHalf, TupVecHalf, TupVecFloat, TupVecFloat,
+             TupVecDouble, TupVecDouble, TupVecBool, TupVecBool, TupVecChar,
+             TupVecChar #-}
+pattern TupInt    :: () => a ~ Int => TupleType a
+pattern TupInt    = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt)))
+pattern TupInt8   :: () => a ~ Int8 => TupleType a
+pattern TupInt8   = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt8)))
+pattern TupInt16  :: () => a ~ Int16 => TupleType a
+pattern TupInt16  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt16)))
+pattern TupInt32  :: () => a ~ Int32 => TupleType a
+pattern TupInt32  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt32)))
+pattern TupInt64  :: () => a ~ Int64 => TupleType a
+pattern TupInt64  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeInt64)))
+pattern TupWord   :: () => a ~ Word => TupleType a
+pattern TupWord   = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord)))
+pattern TupWord8  :: () => a ~ Word8 => TupleType a
+pattern TupWord8  = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord8)))
+pattern TupWord16 :: () => a ~ Word16 => TupleType a
+pattern TupWord16 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord16)))
+pattern TupWord32 :: () => a ~ Word32 => TupleType a
+pattern TupWord32 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord32)))
+pattern TupWord64 :: () => a ~ Word64 => TupleType a
+pattern TupWord64 = TupRsingle (SingleScalarType (NumSingleType (IntegralNumType TypeWord64)))
+pattern TupHalf   :: () => a ~ Half => TupleType a
+pattern TupHalf   = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeHalf)))
+pattern TupFloat  :: () => a ~ Float => TupleType a
+pattern TupFloat  = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeFloat)))
+pattern TupDouble :: () => a ~ Double => TupleType a
+pattern TupDouble = TupRsingle (SingleScalarType (NumSingleType (FloatingNumType TypeDouble)))
+pattern TupBool   :: () => a ~ Bool => TupleType a
+pattern TupBool   = TupRsingle (SingleScalarType (NonNumSingleType TypeBool))
+pattern TupChar   :: () => a ~ Char => TupleType a
+pattern TupChar   = TupRsingle (SingleScalarType (NonNumSingleType TypeChar))
+-- TODO: I can't get the type checker to accept these VectorScalarTypes without
+--       having to manually match all possible options, how should this be done
+--       instead?
+pattern TupVecInt    :: () => (a ~ Int, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt    n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt))))
+pattern TupVecInt8   :: () => (a ~ Int8, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt8   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt8))))
+pattern TupVecInt16  :: () => (a ~ Int16, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt16  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt16))))
+pattern TupVecInt32  :: () => (a ~ Int32, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt32  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt32))))
+pattern TupVecInt64  :: () => (a ~ Int64, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecInt64  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeInt64))))
+pattern TupVecWord   :: () => (a ~ Word, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord))))
+pattern TupVecWord8  :: () => (a ~ Word8, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord8  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord8))))
+pattern TupVecWord16 :: () => (a ~ Word16, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord16 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord16))))
+pattern TupVecWord32 :: () => (a ~ Word32, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord32 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord32))))
+pattern TupVecWord64 :: () => (a ~ Word64, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecWord64 n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (IntegralNumType TypeWord64))))
+pattern TupVecHalf   :: () => (a ~ Half, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecHalf   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeHalf))))
+pattern TupVecFloat  :: () => (a ~ Float, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecFloat  n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeFloat))))
+pattern TupVecDouble :: () => (a ~ Double, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecDouble n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NumSingleType (FloatingNumType TypeDouble))))
+pattern TupVecBool   :: () => (a ~ Bool, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecBool   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NonNumSingleType TypeBool)))
+pattern TupVecChar   :: () => (a ~ Char, v ~ Vec n a) => Int# -> SingleType a -> TupleType v
+pattern TupVecChar   n# tp <- TupRsingle (VectorScalarType (VectorType (I# n#) tp@(NonNumSingleType TypeChar)))
 
 -- | Dense, regular, mutable, multi-dimensional arrays
 --
@@ -69,53 +153,79 @@ instance Elt e => V.MVector MVector e where
   {-# INLINE basicUnsafeCopy  #-}
   basicLength (MArray ((), n) _) = n
 
-  basicUnsafeSlice j m (MArray _ mad) = MArray ((),m) (go arrayElt mad 1)
+  basicUnsafeSlice j m (MArray _ mad) = MArray ((),m) (go (eltType @e) mad 1)
     where
-      go :: ArrayEltR a -> MutableArrayData a -> Int -> MutableArrayData a
-      go ArrayEltRunit           AD_Unit         !_ = AD_Unit
-      go ArrayEltRint            (AD_Int v)      !s = AD_Int     (slice v s)
-      go ArrayEltRint8           (AD_Int8 v)     !s = AD_Int8    (slice v s)
-      go ArrayEltRint16          (AD_Int16 v)    !s = AD_Int16   (slice v s)
-      go ArrayEltRint32          (AD_Int32 v)    !s = AD_Int32   (slice v s)
-      go ArrayEltRint64          (AD_Int64 v)    !s = AD_Int64   (slice v s)
-      go ArrayEltRword           (AD_Word v)     !s = AD_Word    (slice v s)
-      go ArrayEltRword8          (AD_Word8 v)    !s = AD_Word8   (slice v s)
-      go ArrayEltRword16         (AD_Word16 v)   !s = AD_Word16  (slice v s)
-      go ArrayEltRword32         (AD_Word32 v)   !s = AD_Word32  (slice v s)
-      go ArrayEltRword64         (AD_Word64 v)   !s = AD_Word64  (slice v s)
-      go ArrayEltRhalf           (AD_Half v)     !s = AD_Half    (slice v s)
-      go ArrayEltRfloat          (AD_Float v)    !s = AD_Float   (slice v s)
-      go ArrayEltRdouble         (AD_Double v)   !s = AD_Double  (slice v s)
-      go ArrayEltRbool           (AD_Bool v)     !s = AD_Bool    (slice v s)
-      go ArrayEltRchar           (AD_Char v)     !s = AD_Char    (slice v s)
-      go (ArrayEltRvec ae)       (AD_Vec n# v)   !s = AD_Vec n# (go ae v (I# n# * s))
-      go (ArrayEltRpair ae1 ae2) (AD_Pair v1 v2) !s = AD_Pair (go ae1 v1 s) (go ae2 v2 s)
+      go :: TupleType a -> MutableArrayData a -> Int -> MutableArrayData a
+      go TupRunit             ()  !_ = ()
+      go TupInt               arr !s = slice arr s
+      go TupInt8              arr !s = slice arr s
+      go TupInt16             arr !s = slice arr s
+      go TupInt32             arr !s = slice arr s
+      go TupInt64             arr !s = slice arr s
+      go TupWord              arr !s = slice arr s
+      go TupWord8             arr !s = slice arr s
+      go TupWord16            arr !s = slice arr s
+      go TupWord32            arr !s = slice arr s
+      go TupWord64            arr !s = slice arr s
+      go TupHalf              arr !s = slice arr s
+      go TupFloat             arr !s = slice arr s
+      go TupDouble            arr !s = slice arr s
+      go TupBool              arr !s = slice arr s
+      go TupChar              arr !s = slice arr s
+      go (TupVecInt n# tp)    arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecInt8 n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecInt16 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecInt32 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecInt64 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord16 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord32 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord64 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecHalf n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecFloat n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecDouble n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecBool n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecChar n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupRpair t1 t2) (a1, a2) !s = (go t1 a1 s, go t2 a2 s)
 
       slice :: forall a. Storable a => UniqueArray a -> Int -> UniqueArray a
       slice (UniqueArray uid (Lifetime lft w fp)) s =
         UniqueArray uid (Lifetime lft w (plusForeignPtr fp (j * s * sizeOf (undefined::a))))
 
-  basicOverlaps (MArray ((),m) mad1) (MArray ((),n) mad2) = go arrayElt mad1 mad2 1
+  basicOverlaps (MArray ((), m) mad1) (MArray ((), n) mad2) = go (eltType @e) mad1 mad2 1
     where
-      go :: ArrayEltR a -> MutableArrayData a -> MutableArrayData a -> Int -> Bool
-      go ArrayEltRunit           AD_Unit           AD_Unit           !_ = False
-      go ArrayEltRint            (AD_Int v1)       (AD_Int v2)       !s = overlaps v1 v2 s
-      go ArrayEltRint8           (AD_Int8 v1)      (AD_Int8 v2)      !s = overlaps v1 v2 s
-      go ArrayEltRint16          (AD_Int16 v1)     (AD_Int16 v2)     !s = overlaps v1 v2 s
-      go ArrayEltRint32          (AD_Int32 v1)     (AD_Int32 v2)     !s = overlaps v1 v2 s
-      go ArrayEltRint64          (AD_Int64 v1)     (AD_Int64 v2)     !s = overlaps v1 v2 s
-      go ArrayEltRword           (AD_Word v1)      (AD_Word v2)      !s = overlaps v1 v2 s
-      go ArrayEltRword8          (AD_Word8 v1)     (AD_Word8 v2)     !s = overlaps v1 v2 s
-      go ArrayEltRword16         (AD_Word16 v1)    (AD_Word16 v2)    !s = overlaps v1 v2 s
-      go ArrayEltRword32         (AD_Word32 v1)    (AD_Word32 v2)    !s = overlaps v1 v2 s
-      go ArrayEltRword64         (AD_Word64 v1)    (AD_Word64 v2)    !s = overlaps v1 v2 s
-      go ArrayEltRhalf           (AD_Half v1)      (AD_Half v2)      !s = overlaps v1 v2 s
-      go ArrayEltRfloat          (AD_Float v1)     (AD_Float v2)     !s = overlaps v1 v2 s
-      go ArrayEltRdouble         (AD_Double v1)    (AD_Double v2)    !s = overlaps v1 v2 s
-      go ArrayEltRbool           (AD_Bool v1)      (AD_Bool v2)      !s = overlaps v1 v2 s
-      go ArrayEltRchar           (AD_Char v1)      (AD_Char v2)      !s = overlaps v1 v2 s
-      go (ArrayEltRvec ae)       (AD_Vec n# v1)    (AD_Vec _ v2)     !s = go ae v1 v2 (I# n# * s) -- the type ensures these must be the same vector width
-      go (ArrayEltRpair ae1 ae2) (AD_Pair v11 v12) (AD_Pair v21 v22) !s = go ae1 v11 v21 s || go ae2 v12 v22 s
+      go :: TupleType a -> MutableArrayData a -> MutableArrayData a -> Int -> Bool
+      go TupRunit             () () !_ = False
+      go TupInt               a1 a2 !s = overlaps a1 a2 s
+      go TupInt8              a1 a2 !s = overlaps a1 a2 s
+      go TupInt16             a1 a2 !s = overlaps a1 a2 s
+      go TupInt32             a1 a2 !s = overlaps a1 a2 s
+      go TupInt64             a1 a2 !s = overlaps a1 a2 s
+      go TupWord              a1 a2 !s = overlaps a1 a2 s
+      go TupWord8             a1 a2 !s = overlaps a1 a2 s
+      go TupWord16            a1 a2 !s = overlaps a1 a2 s
+      go TupWord32            a1 a2 !s = overlaps a1 a2 s
+      go TupWord64            a1 a2 !s = overlaps a1 a2 s
+      go TupHalf              a1 a2 !s = overlaps a1 a2 s
+      go TupFloat             a1 a2 !s = overlaps a1 a2 s
+      go TupDouble            a1 a2 !s = overlaps a1 a2 s
+      go TupBool              a1 a2 !s = overlaps a1 a2 s
+      go TupChar              a1 a2 !s = overlaps a1 a2 s
+      go (TupVecInt n# tp)    a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecInt8 n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecInt16 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecInt32 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecInt64 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord16 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord32 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord64 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecHalf n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecFloat n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecDouble n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecBool n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecChar n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupRpair t1 t2) (l1, r1) (l2, r2) !s = go t1 l1 l2 s || go t2 r1 r2 s
 
       overlaps :: forall a. Storable a => UniqueArray a -> UniqueArray a -> Int -> Bool
       overlaps (UniqueArray _ (Lifetime _ _ (ForeignPtr addr1# c1))) (UniqueArray _ (Lifetime _ _ (ForeignPtr addr2# c2))) s =
@@ -134,63 +244,83 @@ instance Elt e => V.MVector MVector e where
       between :: Int -> Int -> Int -> Bool
       between x y z = x >= y && x < z
 
-  basicUnsafeNew n = unsafePrimToPrim $ MArray ((),n) <$> newArrayData n
+  basicUnsafeNew n = unsafePrimToPrim $ MArray ((), n) <$> newArrayData (eltType @e) n
 
-  basicInitialize (MArray ((),n) mad) = unsafePrimToPrim $ go (arrayElt :: ArrayEltR (EltRepr e)) (ptrsOfArrayData mad) 1
+  basicInitialize (MArray ((),n) mad) = unsafePrimToPrim $ go (eltType @e) mad 1
     where
-      go :: ArrayEltR a -> ArrayPtrs a -> Int -> IO ()
-      go ArrayEltRunit           () !_ = return ()
-      go ArrayEltRint            p  !s = initialise p s
-      go ArrayEltRint8           p  !s = initialise p s
-      go ArrayEltRint16          p  !s = initialise p s
-      go ArrayEltRint32          p  !s = initialise p s
-      go ArrayEltRint64          p  !s = initialise p s
-      go ArrayEltRword           p  !s = initialise p s
-      go ArrayEltRword8          p  !s = initialise p s
-      go ArrayEltRword16         p  !s = initialise p s
-      go ArrayEltRword32         p  !s = initialise p s
-      go ArrayEltRword64         p  !s = initialise p s
-      go ArrayEltRhalf           p  !s = initialise p s
-      go ArrayEltRfloat          p  !s = initialise p s
-      go ArrayEltRdouble         p  !s = initialise p s
-      go ArrayEltRbool           p  !s = initialise p s
-      go ArrayEltRchar           p  !s = initialise p s
-      go aeR@(ArrayEltRvec ae)   p  !s = go ae p (s * width aeR)
-      go (ArrayEltRpair ae1 ae2) (p1,p2) !s = go ae1 p1 s >> go ae2 p2 s
-
-      width :: forall n a. KnownNat n => ArrayEltR (Vec n a) -> Int
-      width _ = fromInteger (natVal' (proxy# :: Proxy# n))
+      go :: TupleType a -> MutableArrayData a -> Int -> IO ()
+      go TupRunit             ()  !_ = return ()
+      go TupInt               arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupInt8              arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupInt16             arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupInt32             arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupInt64             arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupWord              arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupWord8             arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupWord16            arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupWord32            arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupWord64            arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupHalf              arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupFloat             arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupDouble            arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupBool              arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go TupChar              arr !s = initialise (unsafeUniqueArrayPtr arr) s
+      go (TupVecInt n# tp)    arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecInt8 n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecInt16 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecInt32 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecInt64 n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord16 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord32 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecWord64 n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecHalf n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecFloat n# tp)  arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecDouble n# tp) arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecBool n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupVecChar n# tp)   arr !s = go (TupRsingle $ SingleScalarType tp) arr (I# n# * s)
+      go (TupRpair t1 t2) (a1, a2) !s = go t1 a1 s >> go t2 a2 s
 
       initialise :: forall a. Storable a => Ptr a -> Int -> IO ()
       initialise p s = fillBytes p 0 (n * s * sizeOf (undefined::a))
 
-  basicUnsafeRead  (MArray _ mad) i   = unsafePrimToPrim $ toElt <$> unsafeReadArrayData mad i
-  basicUnsafeWrite (MArray _ mad) i v = unsafePrimToPrim $ unsafeWriteArrayData mad i (fromElt v)
+  basicUnsafeRead  (MArray _ mad) i   = unsafePrimToPrim $ toElt <$> unsafeReadArrayData (eltType @e) mad i
+  basicUnsafeWrite (MArray _ mad) i v = unsafePrimToPrim $ unsafeWriteArrayData (eltType @e) mad i (fromElt v)
 
-  basicUnsafeCopy (MArray _ dst) (MArray ((),n) src) = unsafePrimToPrim $ go (arrayElt :: ArrayEltR (EltRepr e)) (ptrsOfArrayData dst) (ptrsOfArrayData src) 1
+  basicUnsafeCopy (MArray _ dst) (MArray ((), n) src) = unsafePrimToPrim $ go (eltType @e) dst src 1
     where
-      go :: ArrayEltR a -> ArrayPtrs a -> ArrayPtrs a -> Int -> IO ()
-      go ArrayEltRunit           () () !_ = return ()
-      go ArrayEltRint            u  v  !s = copy u v s
-      go ArrayEltRint8           u  v  !s = copy u v s
-      go ArrayEltRint16          u  v  !s = copy u v s
-      go ArrayEltRint32          u  v  !s = copy u v s
-      go ArrayEltRint64          u  v  !s = copy u v s
-      go ArrayEltRword           u  v  !s = copy u v s
-      go ArrayEltRword8          u  v  !s = copy u v s
-      go ArrayEltRword16         u  v  !s = copy u v s
-      go ArrayEltRword32         u  v  !s = copy u v s
-      go ArrayEltRword64         u  v  !s = copy u v s
-      go ArrayEltRhalf           u  v  !s = copy u v s
-      go ArrayEltRfloat          u  v  !s = copy u v s
-      go ArrayEltRdouble         u  v  !s = copy u v s
-      go ArrayEltRbool           u  v  !s = copy u v s
-      go ArrayEltRchar           u  v  !s = copy u v s
-      go aeR@(ArrayEltRvec ae)   u  v  !s = go ae u v (s * width aeR)
-      go (ArrayEltRpair ae1 ae2) (u1,u2) (v1,v2) !s = go ae1 u1 v1 s >> go ae2 u2 v2 s
-
-      width :: forall n a. KnownNat n => ArrayEltR (Vec n a) -> Int
-      width _ = fromInteger (natVal' (proxy# :: Proxy# n))
+      go :: TupleType a -> MutableArrayData a -> MutableArrayData a -> Int -> IO ()
+      go TupRunit             () () !_ = return ()
+      go TupInt               a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupInt8              a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupInt16             a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupInt32             a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupInt64             a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupWord              a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupWord8             a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupWord16            a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupWord32            a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupWord64            a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupHalf              a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupFloat             a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupDouble            a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupBool              a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go TupChar              a1 a2 !s = copy (unsafeUniqueArrayPtr a1) (unsafeUniqueArrayPtr a2) s
+      go (TupVecInt n# tp)    a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecInt8 n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecInt16 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecInt32 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecInt64 n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord16 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord32 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecWord64 n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecHalf n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecFloat n# tp)  a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecDouble n# tp) a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecBool n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupVecChar n# tp)   a1 a2 !s = go (TupRsingle $ SingleScalarType tp) a1 a2 (I# n# * s)
+      go (TupRpair t1 t2) (l1, r1) (l2, r2) !s = go t1 l1 l2 s >> go t2 r1 r2 s
 
       copy :: forall a. Storable a => Ptr a -> Ptr a -> Int -> IO ()
       copy u v s = copyBytes u v (n * s * sizeOf (undefined::a))

--- a/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Vector/Unboxed.hs
+++ b/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Vector/Unboxed.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
+
 -- |
 -- Module      : Data.Array.Accelerate.IO.Data.Vector.Unboxed
 -- Copyright   : [2017..2019] The Accelerate Team
@@ -47,7 +49,7 @@ import Data.Word
 --
 {-# INLINE fromUnboxed #-}
 fromUnboxed :: Unbox e => Vector e -> Array DIM1 e
-fromUnboxed v = Array ((), U.length v) (arrayDataOfUnboxed v)
+fromUnboxed v = Array $ R.Array ((), U.length v) (arrayDataOfUnboxed v)
 
 
 -- | /O(1)/ (typically). Convert an Accelerate array into an Unboxed vector.
@@ -58,8 +60,8 @@ fromUnboxed v = Array ((), U.length v) (arrayDataOfUnboxed v)
 -- @since 1.1.0.0@
 --
 {-# INLINE toUnboxed #-}
-toUnboxed :: (Shape sh, Unbox e) => Array sh e -> Vector e
-toUnboxed (Array sh adata) = unboxedOfArrayData (R.size sh) adata
+toUnboxed :: forall sh e. (Shape sh, Unbox e) => Array sh e -> Vector e
+toUnboxed (Array (R.Array sh adata)) = unboxedOfArrayData (R.size (shapeR @sh) sh) adata
 
 
 -- Instances
@@ -72,113 +74,111 @@ class (U.Unbox e, A.Elt e) => Unbox e where
 instance Unbox Int where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Int v) = AD_Int (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Int v) = V_Int (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Int v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Int (vectorOfUniqueArray n arr)
 
 instance Unbox Int8 where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Int8 v) = AD_Int8 (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Int8 v) = V_Int8 (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Int8 v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Int8 (vectorOfUniqueArray n arr)
 
 instance Unbox Int16 where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Int16 v) = AD_Int16 (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Int16 v) = V_Int16 (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Int16 v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Int16 (vectorOfUniqueArray n arr)
 
 instance Unbox Int32 where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Int32 v) = AD_Int32 (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Int32 v) = V_Int32 (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Int32 v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Int32 (vectorOfUniqueArray n arr)
 
 instance Unbox Int64 where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Int64 v)  = AD_Int64 (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Int64 v) = V_Int64 (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Int64 v)  = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Int64 (vectorOfUniqueArray n arr)
 
 instance Unbox Word where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Word v) = AD_Word (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Word v) = V_Word (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Word v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Word (vectorOfUniqueArray n arr)
 
 instance Unbox Word8 where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Word8 v) = AD_Word8 (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Word8 v) = V_Word8 (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Word8 v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Word8 (vectorOfUniqueArray n arr)
 
 instance Unbox Word16 where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Word16 v) = AD_Word16 (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Word16 v) = V_Word16 (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Word16 v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Word16 (vectorOfUniqueArray n arr)
 
 instance Unbox Word32 where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Word32 v) = AD_Word32 (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Word32 v) = V_Word32 (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Word32 v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Word32 (vectorOfUniqueArray n arr)
 
 instance Unbox Word64 where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Word64 v) = AD_Word64 (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Word64 v) = V_Word64 (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Word64 v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Word64 (vectorOfUniqueArray n arr)
 
 instance Unbox Float where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Float v) = AD_Float (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Float v) = V_Float (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Float v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Float (vectorOfUniqueArray n arr)
 
 instance Unbox Double where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Double v) = AD_Double (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Double v) = V_Double (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Double v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Double (vectorOfUniqueArray n arr)
 
 instance Unbox Char where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Char v) = AD_Char (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Char v) = V_Char (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Char v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Char (vectorOfUniqueArray n arr)
 
 instance Unbox Bool where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed (V_Bool v) = AD_Bool (uniqueArrayOfVector v)
-  unboxedOfArrayData !n (AD_Bool v) = V_Bool (vectorOfUniqueArray n v)
+  arrayDataOfUnboxed (V_Bool v) = uniqueArrayOfVector v
+  unboxedOfArrayData !n arr = V_Bool (vectorOfUniqueArray n arr)
 
 instance Unbox () where
   {-# INLINE arrayDataOfUnboxed #-}
   {-# INLINE unboxedOfArrayData #-}
-  arrayDataOfUnboxed V_Unit{} = AD_Unit
-  unboxedOfArrayData !n AD_Unit = V_Unit n
+  arrayDataOfUnboxed V_Unit{} = ()
+  unboxedOfArrayData !n () = V_Unit n
 
+-- TODO: Are there any helpers for
 instance (Unbox a, Unbox b) => Unbox (a, b) where
   {-# INLINE arrayDataOfUnboxed #-}
   arrayDataOfUnboxed (V_2 _ a b) =
-    AD_Unit `AD_Pair` arrayDataOfUnboxed a
-            `AD_Pair` arrayDataOfUnboxed b
+    (((), arrayDataOfUnboxed a), arrayDataOfUnboxed b)
   --
   {-# INLINE unboxedOfArrayData #-}
-  unboxedOfArrayData !n (AD_Unit `AD_Pair` a `AD_Pair` b) =
+  unboxedOfArrayData !n (((), a), b) =
     V_2 n (unboxedOfArrayData n a)
           (unboxedOfArrayData n b)
 
 instance (Unbox a, Unbox b, Unbox c) => Unbox (a, b, c) where
   {-# INLINE arrayDataOfUnboxed #-}
   arrayDataOfUnboxed (V_3 _ a b c) =
-    AD_Unit `AD_Pair` arrayDataOfUnboxed a
-            `AD_Pair` arrayDataOfUnboxed b
-            `AD_Pair` arrayDataOfUnboxed c
+    ((((), arrayDataOfUnboxed a), arrayDataOfUnboxed b), arrayDataOfUnboxed c)
   --
   {-# INLINE unboxedOfArrayData #-}
-  unboxedOfArrayData !n (AD_Unit `AD_Pair` a `AD_Pair` b `AD_Pair` c) =
+  unboxedOfArrayData !n ((((), a), b), c) =
     V_3 n (unboxedOfArrayData n a)
           (unboxedOfArrayData n b)
           (unboxedOfArrayData n c)
@@ -186,13 +186,14 @@ instance (Unbox a, Unbox b, Unbox c) => Unbox (a, b, c) where
 instance (Unbox a, Unbox b, Unbox c, Unbox d) => Unbox (a, b, c, d) where
   {-# INLINE arrayDataOfUnboxed #-}
   arrayDataOfUnboxed (V_4 _ a b c d) =
-    AD_Unit `AD_Pair` arrayDataOfUnboxed a
-            `AD_Pair` arrayDataOfUnboxed b
-            `AD_Pair` arrayDataOfUnboxed c
-            `AD_Pair` arrayDataOfUnboxed d
+    (((((),
+         arrayDataOfUnboxed a),
+        arrayDataOfUnboxed b),
+       arrayDataOfUnboxed c),
+      arrayDataOfUnboxed d)
   --
   {-# INLINE unboxedOfArrayData #-}
-  unboxedOfArrayData !n (AD_Unit `AD_Pair` a `AD_Pair` b `AD_Pair` c `AD_Pair` d) =
+  unboxedOfArrayData !n (((((), a), b), c), d) =
     V_4 n (unboxedOfArrayData n a)
           (unboxedOfArrayData n b)
           (unboxedOfArrayData n c)
@@ -201,14 +202,15 @@ instance (Unbox a, Unbox b, Unbox c, Unbox d) => Unbox (a, b, c, d) where
 instance (Unbox a, Unbox b, Unbox c, Unbox d, Unbox e) => Unbox (a, b, c, d, e) where
   {-# INLINE arrayDataOfUnboxed #-}
   arrayDataOfUnboxed (V_5 _ a b c d e) =
-    AD_Unit `AD_Pair` arrayDataOfUnboxed a
-            `AD_Pair` arrayDataOfUnboxed b
-            `AD_Pair` arrayDataOfUnboxed c
-            `AD_Pair` arrayDataOfUnboxed d
-            `AD_Pair` arrayDataOfUnboxed e
+    ((((((),
+          arrayDataOfUnboxed a),
+         arrayDataOfUnboxed b),
+        arrayDataOfUnboxed c),
+       arrayDataOfUnboxed d),
+      arrayDataOfUnboxed e)
   --
   {-# INLINE unboxedOfArrayData #-}
-  unboxedOfArrayData !n (AD_Unit `AD_Pair` a `AD_Pair` b `AD_Pair` c `AD_Pair` d `AD_Pair` e) =
+  unboxedOfArrayData !n ((((((), a), b), c), d), e) =
     V_5 n (unboxedOfArrayData n a)
           (unboxedOfArrayData n b)
           (unboxedOfArrayData n c)
@@ -218,21 +220,24 @@ instance (Unbox a, Unbox b, Unbox c, Unbox d, Unbox e) => Unbox (a, b, c, d, e) 
 instance (Unbox a, Unbox b, Unbox c, Unbox d, Unbox e, Unbox f) => Unbox (a, b, c, d, e, f) where
   {-# INLINE arrayDataOfUnboxed #-}
   arrayDataOfUnboxed (V_6 _ a b c d e f) =
-    AD_Unit `AD_Pair` arrayDataOfUnboxed a
-            `AD_Pair` arrayDataOfUnboxed b
-            `AD_Pair` arrayDataOfUnboxed c
-            `AD_Pair` arrayDataOfUnboxed d
-            `AD_Pair` arrayDataOfUnboxed e
-            `AD_Pair` arrayDataOfUnboxed f
+    (((((((),
+           arrayDataOfUnboxed a),
+          arrayDataOfUnboxed b),
+         arrayDataOfUnboxed c),
+        arrayDataOfUnboxed d),
+       arrayDataOfUnboxed e),
+      arrayDataOfUnboxed f)
   --
   {-# INLINE unboxedOfArrayData #-}
-  unboxedOfArrayData !n (AD_Unit `AD_Pair` a `AD_Pair` b `AD_Pair` c `AD_Pair` d `AD_Pair` e `AD_Pair` f) =
+  unboxedOfArrayData !n (((((((), a), b), c), d), e), f) =
     V_6 n (unboxedOfArrayData n a)
           (unboxedOfArrayData n b)
           (unboxedOfArrayData n c)
           (unboxedOfArrayData n d)
           (unboxedOfArrayData n e)
           (unboxedOfArrayData n f)
+
+-- TODO: What should be done with the commented out code below?
 
 {--
 #if MIN_VERSION_vector(0,12,0)

--- a/accelerate-io/accelerate-io.cabal
+++ b/accelerate-io/accelerate-io.cabal
@@ -30,8 +30,8 @@ Extra-source-files:
 
 library
   build-depends:
-          base            >= 4.8 && < 4.13
-        , accelerate      >= 1.3
+          base            >= 4.10 && < 4.14
+        , accelerate      >= 1.4
 
   exposed-modules:
         Data.Array.Accelerate.IO.Foreign.Ptr

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -15,7 +15,7 @@ packages:
 
 extra-deps:
 - github: tmcdonell/accelerate
-  commit: 5c2c1db205fcf1e0777ef9399959100b75e7bbec
+  commit: fe5b5430a3867cc15b2631fdd6aa3058283ce5f7
 
 - half-0.3
 - hashtables-1.2.3.1

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -15,7 +15,7 @@ packages:
 
 extra-deps:
 - github: tmcdonell/accelerate
-  commit: 5c2c1db205fcf1e0777ef9399959100b75e7bbec
+  commit: fe5b5430a3867cc15b2631fdd6aa3058283ce5f7
 
 - half-0.3
 

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -14,8 +14,8 @@ packages:
 - accelerate-io-vector
 
 extra-deps:
-- github: tmcdonell/accelerate
-  commit: fe5b5430a3867cc15b2631fdd6aa3058283ce5f7
+- github: AccelerateHS/accelerate
+  commit: de95f21285a0a39df8b391e27bdf4a47890debb9
 
 - half-0.3
 

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -15,7 +15,7 @@ packages:
 
 extra-deps:
 - github: tmcdonell/accelerate
-  commit: 5c2c1db205fcf1e0777ef9399959100b75e7bbec
+  commit: fe5b5430a3867cc15b2631fdd6aa3058283ce5f7
 
 - primitive-0.6.4.0
 

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -14,8 +14,8 @@ packages:
 - accelerate-io-vector
 
 extra-deps:
-- github: tmcdonell/accelerate
-  commit: fe5b5430a3867cc15b2631fdd6aa3058283ce5f7
+- github: AccelerateHS/accelerate
+  commit: de95f21285a0a39df8b391e27bdf4a47890debb9
 
 - primitive-0.6.4.0
 

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 # vim: nospell
 
-resolver: lts-13.25
+resolver: lts-14.14
 
 packages:
 - accelerate-io
@@ -15,7 +15,7 @@ packages:
 
 extra-deps:
 - github: tmcdonell/accelerate
-  commit: 5c2c1db205fcf1e0777ef9399959100b75e7bbec
+  commit: fe5b5430a3867cc15b2631fdd6aa3058283ce5f7
 
 - hedgehog-1.0
 - tasty-hedgehog-1.0.0.1

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 # vim: nospell
 
-resolver: lts-14.14
+resolver: lts-14.27
 
 packages:
 - accelerate-io
@@ -14,11 +14,8 @@ packages:
 - accelerate-io-vector
 
 extra-deps:
-- github: tmcdonell/accelerate
-  commit: fe5b5430a3867cc15b2631fdd6aa3058283ce5f7
-
-- hedgehog-1.0
-- tasty-hedgehog-1.0.0.1
+- github: AccelerateHS/accelerate
+  commit: de95f21285a0a39df8b391e27bdf4a47890debb9
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack-8.8.yaml
+++ b/stack-8.8.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 # vim: nospell
 
-resolver: lts-9.21
+resolver: lts-15.15
 
 packages:
 - accelerate-io
@@ -14,18 +14,16 @@ packages:
 - accelerate-io-vector
 
 extra-deps:
-- github: tmcdonell/accelerate
-  commit: fe5b5430a3867cc15b2631fdd6aa3058283ce5f7
+- github: AccelerateHS/accelerate
+  commit: de95f21285a0a39df8b391e27bdf4a47890debb9
 
-- half-0.3
-- hashtables-1.2.3.1
-- prettyprinter-1.3.0
-- primitive-0.6.4.0
-- repa-3.4.1.3
-- tasty-hedgehog-0.2.0.0
+- repa-3.4.1.4
 
 # Override default flag values for local packages and extra-deps
 # flags: {}
+
+# Extra global and per-package GHC options
+# ghc-options: {}
 
 # Extra package databases containing global packages
 # extra-package-dbs: []


### PR DESCRIPTION
Hi,

I updated the `accelerate-io-vector` instances for the new internal array representation and I wanted to get some feedback before continuing with the rest of the packages. When I tried using these updated instances I got some corrupt results at first so I did not post them earlier, but I tracked the issue down to a regression in `accelerate-llvm-ptx` and I'll have to investigate that some more later (same thing happens with `A.toList`, and there are no issues with `accelerate-llvm-native`).

So for now I had a few questions regarding style:

1. The replacement of `ArrayEltR a` with `TupleType a` results in some very lengthy pattern matches. I added pattern synonyms for matching the different variants of `TupleType` to keep everything more or less readable (see `accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Patterns.hs`). If this seems like a good approach, then these patterns might need to be defined in some common place (maybe even in Accelerate itself?) to avoid having to define them in place for every package that might need them.
2. I could not get the `{-# COMPLETE #-}` pragma to work like you'd expect for those patterns, and missing some will not issue any pattern checker warnings. Similarly [this](https://github.com/AccelerateHS/accelerate-io/compare/master...robbert-vdh:feature/update-instances#diff-f9a3f59868fd71eddc8aa4c995fa3dd1R90) will cause overlapping pattern warnings even though none of the patterns overlap.
3. Since `UniqueArray a` is now a type family I could not get the type checker to accept that all possible variations of the `TupleType (Vec n a)` will also have an associated `UniqueArray` type without having to manually pattern match all  possible variations. Is there a way around this?

The branch is based on @tmcdonell's fork of accelerate-io.