### PR TITLE
Fix compilation errors in array and vector library

### DIFF
--- a/accelerate-io-array/src/Data/Array/Accelerate/IO/Data/Primitive/ByteArray.hs
+++ b/accelerate-io-array/src/Data/Array/Accelerate/IO/Data/Primitive/ByteArray.hs
@@ -18,6 +18,7 @@ module Data.Array.Accelerate.IO.Data.Primitive.ByteArray
 import Data.Primitive.ByteArray
 
 import GHC.Base
+import GHC.Exts
 import GHC.ForeignPtr
 
 

--- a/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Primitive/ByteArray.hs
+++ b/accelerate-io-vector/src/Data/Array/Accelerate/IO/Data/Primitive/ByteArray.hs
@@ -18,6 +18,7 @@ module Data.Array.Accelerate.IO.Data.Primitive.ByteArray
 import Data.Primitive.ByteArray
 
 import GHC.Base
+import GHC.Exts
 import GHC.ForeignPtr
 
 


### PR DESCRIPTION
unsafeCoerce# has been moved from GHC.Base to GHC.Exts.